### PR TITLE
fix: checkbox filter disappearing fix 

### DIFF
--- a/src/components/data-table/data-table-filter-checkbox.tsx
+++ b/src/components/data-table/data-table-filter-checkbox.tsx
@@ -58,8 +58,6 @@ export function DataTableFilterCheckbox<TData>({
       </div>
     );
 
-  if (!filterOptions?.length) return null;
-
   return (
     <div className="grid gap-2">
       {options && options.length > 4 ? (
@@ -73,7 +71,7 @@ export function DataTableFilterCheckbox<TData>({
       ) : null}
       {/* FIXME: due to the added max-h and overflow-y-auto, the hover state and border is laying on top of the scroll bar */}
       <div className="max-h-[200px] overflow-y-auto rounded-lg border border-border empty:border-none">
-        {filterOptions
+        {filterOptions!
           // TODO: we shoudn't sort the options here, instead filterOptions should be sorted by default
           // .sort((a, b) => a.label.localeCompare(b.label))
           .map((option, index) => {
@@ -84,7 +82,7 @@ export function DataTableFilterCheckbox<TData>({
                 key={String(option.value)}
                 className={cn(
                   "group relative flex items-center space-x-2 px-2 py-2.5 hover:bg-accent/50",
-                  index !== filterOptions.length - 1 ? "border-b" : undefined,
+                  index !== filterOptions!.length - 1 ? "border-b" : undefined,
                 )}
               >
                 <Checkbox


### PR DESCRIPTION
This is a potential resolution to the issue of the checkbox component disappearing entirely when the user filters down to the point where no results are returned. I'm not sure if this will have any knock-on effects across the repo.

## How to replicate: 
1. Go to https://data-table.openstatus.dev/infinite.
2. Select Regions in the filter list
3. Type '1' or any other text that does not have any matches

## Fix:
Will no longer return null for the whole component. This way, the options disappear as intended, allowing the user to alter the text input to see more results.


## Issue
https://github.com/user-attachments/assets/d48fea92-b160-4768-9a8a-d63fe10b3f41

## Fixed Version
https://github.com/user-attachments/assets/126c89a2-8c10-43b8-a3b8-2e3699cf4ee1
